### PR TITLE
Drop getconf check in TestGetPresent

### DIFF
--- a/numcpus_test.go
+++ b/numcpus_test.go
@@ -101,6 +101,4 @@ func TestGetPresent(t *testing.T) {
 		t.Fatalf("GetPresent: %v", err)
 	}
 	t.Logf("Present = %v", n)
-
-	testGetconf(t, n, "GetPresent", "_NPROCESSORS_CONF")
 }


### PR DESCRIPTION
It seems the assumption that `getconf _NPROCESSORS_CONF` returns
the number of CPUs in `/sys/devices/system/cpu/present` is not always
true on all systems.

Inspecting the code of glibc's getconf implementation it seems the value
returned by `getconf _NPROCESSORS_CONF` is the total number of `cpuN`
directories found in `/sys/devices/system/cpu` while
`numcpus.GetPresent` reads `/sys/devices/system/cpu/present`. Thus, drop
the check to avoid failing tests where this might not be true (such as
on some ppc64 systems.

Fixes #15