### PR TITLE
.cirrus.yml: disable buildvcs on build and test

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -6,8 +6,8 @@ freebsd_12_task:
   freebsd_instance:
     image_family: freebsd-12-3
   install_script: |
-    pkg install -y git go
+    pkg install -y go
     GOBIN=$PWD/bin go install golang.org/dl/${GO_VERSION}@latest
     bin/${GO_VERSION} download
   build_script: bin/${GO_VERSION} build -buildvcs=false -v ./...
-  test_script: bin/${GO_VERSION} test -race ./...
+  test_script: bin/${GO_VERSION} test -buildvcs=false -race ./...


### PR DESCRIPTION
Explicitly disable buildvcs for build and test on FreeBSD. See
https://github.com/golang/go/issues/51723 and
https://github.com/golang/go/issues/51748.