### PR TITLE
.github/workflows: update Go to 1.19, drop 1.16

### DIFF
--- a/.github/workflows/static-analysis.yml
+++ b/.github/workflows/static-analysis.yml
@@ -16,7 +16,7 @@ jobs:
     - name: Install Go
       uses: actions/setup-go@84cbf8094393cdc5fe1fe1671ff2647332956b1a
       with:
-        go-version: '1.18'
+        go-version: '1.19'
 
     - name: Check out code
       uses: actions/checkout@2541b1294d2704b0964813337f33b291d3f8596b

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,7 +12,7 @@ jobs:
   build-and-test:
     strategy:
       matrix:
-        go-version: [1.16, 1.17, 1.18]
+        go-version: [1.17, 1.18, 1.19]
         os: [ubuntu-latest, macos-latest, windows-latest]
     runs-on: ${{ matrix.os }}
 
@@ -26,11 +26,11 @@ jobs:
       uses: actions/checkout@2541b1294d2704b0964813337f33b291d3f8596b
 
     - name: Check formatting
-      if: ${{ matrix.go-version == '1.18' && matrix.os == 'ubuntu-latest' }}
+      if: ${{ matrix.go-version == '1.19' && matrix.os == 'ubuntu-latest' }}
       run: diff -u <(echo -n) <(gofmt -d .)
 
     - name: Check Go modules
-      if: ${{ matrix.go-version == '1.18' && matrix.os == 'ubuntu-latest' }}
+      if: ${{ matrix.go-version == '1.19' && matrix.os == 'ubuntu-latest' }}
       run: |
         go mod tidy
         git diff --exit-code


### PR DESCRIPTION
Also run the formatting and module checks with 1.19. Change the
cross-compile step to run on Ubuntu 22.04 instead of 20.04.