### PR TITLE
go.mod: pin golang.org/x/sys module to v0.2.0

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -2,4 +2,4 @@ module github.com/tklauser/numcpus
 
 go 1.13
 
-require golang.org/x/sys v0.0.0-20220811171246-fbc7d0a398ab
+require golang.org/x/sys v0.2.0

--- a/go.sum
+++ b/go.sum
@@ -1,2 +1,2 @@
-golang.org/x/sys v0.0.0-20220811171246-fbc7d0a398ab h1:2QkjZIsXupsJbJIdSjjUOgWK3aEtzyuh2mPt3l/CkeU=
-golang.org/x/sys v0.0.0-20220811171246-fbc7d0a398ab/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+golang.org/x/sys v0.2.0 h1:ljd4t30dBnAvMZaQCevtY0xLLD0A+bRZXbgLMLU1F/A=
+golang.org/x/sys v0.2.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=


### PR DESCRIPTION
The Go project recently started tagging releases on the golang.org/x/* packages, see [1] for more information. Use the tagged version of golang.org/x/sys to allow dependabot to updates this dependency going forward.