### PR TITLE
.github: drop macos-11 runner

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,7 +14,7 @@ jobs:
       matrix:
         # Oldest supported version is 1.18, plus the latest two releases.
         go-version: ['1.18', '1.21', '1.22']
-        os: [ubuntu-20.04, ubuntu-22.04, macos-11, macos-12, macos-13, macos-14, windows-2019, windows-2022]
+        os: [ubuntu-20.04, ubuntu-22.04, macos-12, macos-13, macos-14, windows-2019, windows-2022]
     runs-on: ${{ matrix.os }}
 
     steps:


### PR DESCRIPTION
The macOS 11 runner image is deprecated and will be removed by 28.6.24.