### PR TITLE
go.mod: update minimum Go version to 1.23.0

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,8 +12,8 @@ jobs:
   build-and-test:
     strategy:
       matrix:
-        # Oldest supported version is 1.18, plus the latest two releases.
-        go-version: ['1.18', '1.23', '1.24']
+        # Latest two supported releases.
+        go-version: ['1.23', '1.24']
         os: [ubuntu-20.04, ubuntu-22.04, ubuntu-24.04, ubuntu-24.04-arm, macos-13, macos-14, macos-15, windows-2019, windows-2022]
     runs-on: ${{ matrix.os }}
 

--- a/go.mod
+++ b/go.mod
@@ -1,5 +1,5 @@
 module github.com/tklauser/numcpus
 
-go 1.18
+go 1.23.0
 
 require golang.org/x/sys v0.30.0


### PR DESCRIPTION
The Go project started to unconditionally update the minimum Go version for golang.org/x/ dependencies to go1.23

> all: upgrade go directive to at least 1.23.0 [generated]
>
> By now Go 1.24.0 has been released, and Go 1.22 is no longer supported
> per the Go Release Policy (https://go.dev/doc/devel/release#policy).
>
> For golang/go#69095.

This means that this package will no longer be able to support any version below that when updating golang.org/x/sys