### PR TITLE
ci: update minimum Go version to 1.25, add Go 1.26

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -1,6 +1,6 @@
 env:
   CIRRUS_CLONE_DEPTH: 1
-  GO_VERSION: go1.25.5
+  GO_VERSION: go1.26.1
 
 freebsd_14_task:
   freebsd_instance:

--- a/.github/workflows/static-analysis.yml
+++ b/.github/workflows/static-analysis.yml
@@ -19,7 +19,7 @@ jobs:
     - name: Install Go
       uses: actions/setup-go@4b73464bb391d4059bd26b0524d20df3927bd417 # v5.0.2
       with:
-        go-version: '1.25'
+        go-version: '1.26'
 
     - name: Install staticcheck
       run: go install honnef.co/go/tools/cmd/staticcheck@latest

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,7 +13,7 @@ jobs:
     strategy:
       matrix:
         # Latest two supported releases.
-        go-version: ['1.24', '1.25']
+        go-version: ['1.25', '1.26']
         os: [ubuntu-22.04, ubuntu-24.04, ubuntu-24.04-arm, macos-14, macos-15, macos-26, windows-2022, windows-2025]
     runs-on: ${{ matrix.os }}
 
@@ -27,11 +27,11 @@ jobs:
         go-version: ${{ matrix.go-version }}
 
     - name: Check formatting
-      if: ${{ matrix.go-version == '1.25' && matrix.os == 'ubuntu-24.04' }}
+      if: ${{ matrix.go-version == '1.26' && matrix.os == 'ubuntu-24.04' }}
       run: diff -u <(echo -n) <(gofmt -d .)
 
     - name: Check Go modules
-      if: ${{ matrix.go-version == '1.25' && matrix.os == 'ubuntu-24.04' }}
+      if: ${{ matrix.go-version == '1.26' && matrix.os == 'ubuntu-24.04' }}
       run: |
         go mod tidy -diff
 

--- a/go.mod
+++ b/go.mod
@@ -1,5 +1,5 @@
 module github.com/tklauser/numcpus
 
-go 1.24.0
+go 1.25.0
 
 require golang.org/x/sys v0.41.0


### PR DESCRIPTION
The Go project started to unconditionally update the minimum Go version for golang.org/x/ dependencies to go1.25

This means that this package will no longer be able to support any version below that when updating golang.org/x/sys

Thus, update the minimum Go version to 1.25.0 and add CI coverage for Go 1.26.