### PR TITLE
ci: fix version comments for actions/setup-go

### DIFF
--- a/.github/workflows/static-analysis.yml
+++ b/.github/workflows/static-analysis.yml
@@ -17,7 +17,7 @@ jobs:
       uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
     - name: Install Go
-      uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v5.0.2
+      uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.3.0
       with:
         go-version: '1.26'
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -22,7 +22,7 @@ jobs:
       uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
     - name: Install Go
-      uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v5.0.2
+      uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.3.0
       with:
         go-version: ${{ matrix.go-version }}
 


### PR DESCRIPTION
These weren't updated by dependabot for some reason. Update them to v6.3.0 after commit 2e65cbb479b6 (".github: bump actions/setup-go from 6.2.0 to 6.3.0") bumped the action to that version.