### PR TITLE
numcpus: return CPU count for GetKernelMax on Linux

### DIFF
--- a/numcpus_linux.go
+++ b/numcpus_linux.go
@@ -119,7 +119,7 @@ func getKernelMax() (int, error) {
 	if err != nil {
 		return 0, err
 	}
-	return int(n), nil
+	return int(n) + 1, nil
 }
 
 func getOffline() (int, error) {


### PR DESCRIPTION
Linux sysfs kernel_max reports the maximum CPU index, not the maximum number of CPUs. Add one before returning it so GetKernelMax matches its documented count semantics.