### PR TITLE
ci, go.mod: update minimum Go version to 1.26, add Go 1.27

### DIFF
--- a/.github/workflows/static-analysis.yml
+++ b/.github/workflows/static-analysis.yml
@@ -19,7 +19,7 @@ jobs:
     - name: Install Go
       uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v6.3.0
       with:
-        go-version: '1.26'
+        go-version: '1.27'
 
     - name: Install staticcheck
       run: go install honnef.co/go/tools/cmd/staticcheck@latest

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,7 +12,7 @@ permissions:
   contents: read
 
 env:
-  GO_VERSION: '1.26.4'
+  GO_VERSION: '1.27.1'
   FREEBSD_RELEASE: '15.0'
   NETBSD_RELEASE: '10.1'
   OPENBSD_RELEASE: '7.9'
@@ -24,7 +24,7 @@ jobs:
     strategy:
       matrix:
         # Latest two supported releases.
-        go-version: ['1.25', '1.26']
+        go-version: ['1.26', '1.27']
         os: [ubuntu-22.04, ubuntu-24.04, ubuntu-24.04-arm, macos-14, macos-15, macos-26, windows-2022, windows-2025]
     runs-on: ${{ matrix.os }}
 
@@ -38,11 +38,11 @@ jobs:
         go-version: ${{ matrix.go-version }}
 
     - name: Check formatting
-      if: ${{ matrix.go-version == '1.26' && matrix.os == 'ubuntu-24.04' }}
+      if: ${{ matrix.go-version == '1.27' && matrix.os == 'ubuntu-24.04' }}
       run: diff -u <(echo -n) <(gofmt -d .)
 
     - name: Check Go modules
-      if: ${{ matrix.go-version == '1.26' && matrix.os == 'ubuntu-24.04' }}
+      if: ${{ matrix.go-version == '1.27' && matrix.os == 'ubuntu-24.04' }}
       run: |
         go mod tidy -diff
 

--- a/go.mod
+++ b/go.mod
@@ -1,5 +1,5 @@
 module github.com/tklauser/numcpus
 
-go 1.25.0
+go 1.26.0
 
 require golang.org/x/sys v0.47.0


### PR DESCRIPTION
The Go project started to unconditionally update the minimum Go version for golang.org/x/ dependencies to go1.26

This means that this package will no longer be able to support any version below that when updating golang.org/x/sys

Thus, update the minimum Go version to 1.26.0 and while at it add CI coverage for Go 1.27.